### PR TITLE
fix formatting and typo

### DIFF
--- a/lectures/generics/index.html
+++ b/lectures/generics/index.html
@@ -253,7 +253,7 @@ In the Java Collections Framework, The class <code>HashSet&lt;T&gt;</code> is de
 Yes, because  we can use a value of type <code>HashSet&lt;Integer&gt;</code>
 anywhere that a <code>Set&lt;?&gt;</code> is expected.
 <code>HashSet&lt;Integer&gt;</code> is a subtype of <code>Set&lt;Integer&gt;</code>
-and <code>et&lt;Integer&gt;</code> is a subtype of <code>Set&lt;?&gt;</code>.
+and <code>Set&lt;Integer&gt;</code> is a subtype of <code>Set&lt;?&gt;</code>.
 By transitivity, <code>HashSet&lt;Integer&gt;</code> is a subtype of <code>Set&lt;?&gt;</code>
 </p>
 </div>

--- a/lectures/parsing/index.html
+++ b/lectures/parsing/index.html
@@ -107,7 +107,7 @@ a pseudo-English grammar corresponding to the parse tree above:
 <p>
 As an abbreviation, when a single nonterminal has multiple productions,
 we can write them all together on the right side separated by a vertical
-bar. For example, the two productions for the nonterminal <i>noun-phrase</i>
+bar. For example, the two productions for the nonterminal <code><i>noun-phrase</i></code>
 could have been expressed more concisely:
 <code><i>noun-phrase</i> → <i>noun</i> | <i>article</i> <i>noun</i></code>.
 This notation is just an abbreviation for writing out multiple productions
@@ -122,8 +122,8 @@ out whether an input string is part of the language of the grammar and to
 construct a parse tree if so.
 </p>
 <p>The language of a grammar can be infinite in size if the grammar is
-<strong>recursive</strong>. For example, the productions <i>noun-phrase → article
-noun</i> and <i>noun → adjective
+<strong>recursive</strong>. For example, the productions <code><i>noun-phrase</i> → <i>article
+noun</i></code> and <code><i>noun</i> → <i>adjective</i></code>
 noun</i> allow us to derive the following noun phrases:
 “the dog”, “the old dog”, “the old old dog”, “the old old old dog”, and so on ad infinitum.
 </p>


### PR DESCRIPTION
- `et` -> `Set` in generics lecture
- fix `<i>`/`<code>` in parsing lecture