### PR TITLE
fix single line comments

### DIFF
--- a/js/colorize.js
+++ b/js/colorize.js
@@ -71,7 +71,7 @@ function colorize_text(t, fromRawCode) {
 	    newt += tokens[i];
 	    linecommenting = true;
 	} else if (linecommenting && tokens[i].match(/\r?\n/)) {
-	    tokens[i] = tokens[i].replace(/(\r?)\n/, "</span>\1\n");
+	    tokens[i] = tokens[i].replace(/(\r?)\n/, "</span>$1\n");
 	    newt += tokens[i];
 	    linecommenting = false;
 	} else if (keywords[tokens[i] + "$"] && !commenting && !instring && !linecommenting) {


### PR DESCRIPTION
Currently, single line comments have a U+0001 at the end of single line comments because of a typo in the regex. 

This issue is visible only webkit-based browsers (such as Safari), where the character is rendered as replacement character, the rectangular box.

Before:
<img width="1576" height="118" alt="CleanShot 2025-11-21 at 18 42 29" src="https://github.com/user-attachments/assets/4087feeb-d4f7-4fea-a48a-4af7541ea142" />

After:
<img width="1552" height="110" alt="CleanShot 2025-11-21 at 18 43 32" src="https://github.com/user-attachments/assets/b4cc5a03-6fa9-42d9-8c48-78962d7e741f" />
